### PR TITLE
Source and target versions cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,11 +64,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
     buildFeatures {
         buildConfig = true
         compose = true

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -22,11 +22,6 @@ android {
         release {
         }
     }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/devto-theme/build.gradle.kts
+++ b/devto-theme/build.gradle.kts
@@ -22,11 +22,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
     buildFeatures {
         compose = true
     }

--- a/features/feature-home/build.gradle.kts
+++ b/features/feature-home/build.gradle.kts
@@ -34,11 +34,6 @@ android {
         }
     }
 
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
     buildFeatures {
         buildConfig = true
         compose = true


### PR DESCRIPTION
Can be removed because 1.8 is default from kotlin 1.5.0
https://blog.jetbrains.com/kotlin/2021/05/kotlin-1-5-0-released/